### PR TITLE
Fix: Enable scrolling in ProUpgradeModal drawer

### DIFF
--- a/src/components/ProUpgradeModal.jsx
+++ b/src/components/ProUpgradeModal.jsx
@@ -148,7 +148,7 @@ const ProUpgradeModal = ({ isOpen, onOpenChange, userId }) => {
           <DrawerHeader>
             <DrawerTitle className="sr-only">Upgrade to Pro</DrawerTitle>
           </DrawerHeader>
-          <ScrollArea className="px-4 pb-8 max-h-[calc(80vh-50px)]">
+          <ScrollArea className="px-4 pb-8 max-h-[calc(80vh-theme(spacing.16))] overflow-y-auto">
             {content}
           </ScrollArea>
         </DrawerContent>


### PR DESCRIPTION
The drawer content within the ProUpgradeModal was not fully scrollable on mobile views.

This commit addresses the issue by:
- Adjusting the `max-h` property of the `ScrollArea` component in the mobile drawer to allow more content height.
- Explicitly adding `overflow-y-auto` to ensure scrollability.

The drawer should now be fully scrollable in mobile view, consistent with other drawers in the application.